### PR TITLE
Preallocate buffers for a fast fft and ifft

### DIFF
--- a/fft_example_1D.jl
+++ b/fft_example_1D.jl
@@ -1,6 +1,4 @@
 using Random, Distributions
-using MadNLP
-
 Random.seed!(1)
 
 include("fft_model.jl")

--- a/fft_example_2D.jl
+++ b/fft_example_2D.jl
@@ -1,6 +1,4 @@
 using Random, Distributions
-using MadNLP
-
 Random.seed!(1)
 
 include("fft_model.jl")
@@ -48,7 +46,7 @@ nlp = FFTNLPModel(parameters)
 # Solve with MadNLP/LBFGS
 # solver = MadNLP.MadNLPSolver(nlp; hessian_approximation=MadNLP.CompactLBFGS)
 # results = MadNLP.solve!(solver)
-# beta_MadNLP = results.solution[1:Nt]
+# beta_MadNLP = results.solution[1:Nt*Ns]
 
 # Solve with MadNLP/CG
 solver = MadNLP.MadNLPSolver(
@@ -62,4 +60,4 @@ solver = MadNLP.MadNLPSolver(
     richardson_tol=1e-8,
 )
 results = MadNLP.solve!(solver)
-beta_MadNLP = results.solution[1:Nt]
+beta_MadNLP = results.solution[1:Nt*Ns]

--- a/fft_example_2D.jl
+++ b/fft_example_2D.jl
@@ -1,4 +1,6 @@
 using Random, Distributions
+using MadNLP
+
 Random.seed!(1)
 
 include("fft_model.jl")

--- a/fft_example_3D.jl
+++ b/fft_example_3D.jl
@@ -1,4 +1,6 @@
 using Random, Distributions
+using MadNLP
+
 Random.seed!(1)
 
 include("fft_model.jl")

--- a/fft_example_3D.jl
+++ b/fft_example_3D.jl
@@ -1,6 +1,4 @@
 using Random, Distributions
-using MadNLP
-
 Random.seed!(1)
 
 include("fft_model.jl")
@@ -34,6 +32,12 @@ index_missing_Cartesian, z_zero = punching(DFTdim, DFTsize, centers, radius, y)
 M_perptz = M_perp_tz_wei(DFTdim, DFTsize, z_zero)
 lambda = 5
 
+alpha_LS = 0.1
+gamma_LS = 0.8
+eps_NT = 1e-6
+eps_barrier = 1e-6
+mu_barrier = 10
+
 parameters = FFTParameters(DFTdim, DFTsize, M_perptz, lambda, index_missing_Cartesian, alpha_LS, gamma_LS, eps_NT, mu_barrier, eps_barrier)
 
 t_init = 1
@@ -45,7 +49,7 @@ nlp = FFTNLPModel(parameters)
 # Solve with MadNLP/LBFGS
 # solver = MadNLP.MadNLPSolver(nlp; hessian_approximation=MadNLP.CompactLBFGS)
 # results = MadNLP.solve!(solver)
-# beta_MadNLP = results.solution[1:Nt]
+# beta_MadNLP = results.solution[1:N1*N2*N3]
 
 # Solve with MadNLP/CG
 solver = MadNLP.MadNLPSolver(
@@ -59,4 +63,4 @@ solver = MadNLP.MadNLPSolver(
     richardson_tol=1e-8,
 )
 results = MadNLP.solve!(solver)
-beta_MadNLP = results.solution[1:Nt]
+beta_MadNLP = results.solution[1:N1*N2*N3]

--- a/fft_vishwas.jl
+++ b/fft_vishwas.jl
@@ -1,7 +1,6 @@
 using Random, Distributions
 using LinearAlgebra, SparseArrays
 using LaplaceInterpolation, NPZ
-using MadNLP
 
 include("fft_model.jl")
 
@@ -70,13 +69,13 @@ nlp = FFTNLPModel(parameters)
 # Solve with MadNLP/CG
 solver = MadNLP.MadNLPSolver(
     nlp;
-    max_iter=200,
+    max_iter=2000,
     kkt_system=FFTKKTSystem,
     print_level=MadNLP.INFO,
     dual_initialized=true,
-    richardson_max_iter=10,
+    richardson_max_iter=0,
     tol=1e-8,
-    richardson_tol=1e-8,
+    richardson_tol=Inf,
 )
 results = MadNLP.solve!(solver)
 beta_MadNLP = results.solution[1:Nt]

--- a/kkt.jl
+++ b/kkt.jl
@@ -2,6 +2,7 @@
 using LinearAlgebra
 using SparseArrays
 using Krylov
+using MadNLP
 
 #=
     Operator for matrix


### PR DESCRIPTION
@frapac
En dehors de `DFT_to_beta` et `beta_to_DFT`, l'opérateur `H * v` est in-place.
Ça devrait nous donner un bon sur speed-up le problème de Vishwas.
