### PR TITLE
Deactivate scaling in MadNLP

### DIFF
--- a/fft_example_1D.jl
+++ b/fft_example_1D.jl
@@ -61,6 +61,7 @@ function fft_example_1D(Nt::Int; gpu::Bool=false, rdft::Bool=false, check::Bool=
         nlp;
         max_iter=2000,
         kkt_system=FFTKKTSystem,
+        nlp_scaling=false,
         print_level=MadNLP.INFO,
         dual_initialized=true,
         richardson_max_iter=0,

--- a/fft_example_2D.jl
+++ b/fft_example_2D.jl
@@ -60,6 +60,7 @@ function fft_example_2D(Nt::Int, Ns::Int; gpu::Bool=false, rdft::Bool=false, che
         nlp;
         max_iter=2000,
         kkt_system=FFTKKTSystem,
+        nlp_scaling=false,
         print_level=MadNLP.INFO,
         dual_initialized=true,
         richardson_max_iter=0,

--- a/fft_example_3D.jl
+++ b/fft_example_3D.jl
@@ -1,5 +1,6 @@
 using Random, Distributions
 using MadNLPGPU, CUDA
+using Test
 Random.seed!(1)
 
 include("fft_model.jl")
@@ -62,6 +63,7 @@ function fft_example_3D(N1::Int, N2::Int, N3::Int; gpu::Bool=false, rdft::Bool=f
         max_iter=2000,
         kkt_system=FFTKKTSystem,
         print_level=MadNLP.INFO,
+        nlp_scaling=false,
         dual_initialized=true,
         richardson_max_iter=0,
         tol=1e-6,


### PR DESCRIPTION
The scaling applied automatically by MadNLP is not adapted for Compressed Sensing. If we deactivate the scaling, we get much better convergence. 

E.g., here is the convergence we obtain on the 3D example, with size 64x64x64:

```
Number of nonzeros in constraint Jacobian............:        1                                                                                                                                                                                
Number of nonzeros in Lagrangian Hessian.............:        1                                                                                                                                                                                
                                                                                                                                                                                                                                               
Total number of variables............................:   524288                                                                                                                                                                                
                     variables with only lower bounds:        0                                                                                                                                                                                
                variables with lower and upper bounds:        0                                                                                                                                                                                
                     variables with only upper bounds:        0                                                                                                                                                                                
Total number of equality constraints.................:        0                 
Total number of inequality constraints...............:   524288                 
        inequality constraints with only lower bounds:        0                 
   inequality constraints with lower and upper bounds:        0                 
        inequality constraints with only upper bounds:   524288                 
                                                                                                                       
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
   0  0.0000000e+00 1.00e-02 8.88e+02  -1.0 0.00e+00    -  0.00e+00 0.00e+00   0
   1  2.1178579e+02 9.98e-03 8.86e+02  -1.0 4.49e+00    -  2.25e-03 2.28e-03h  1
   2 -1.4686325e+03 9.91e-03 8.80e+02  -1.0 6.22e+02    -  3.28e-05 6.48e-03h  1
   3 -2.9515644e+04 9.77e-03 8.67e+02  -1.0 1.97e+03    -  4.95e-04 1.43e-02h  1
   4 -5.7020144e+05 7.76e-03 6.89e+02  -1.0 1.95e+03    -  2.55e-03 2.05e-01h  1
   5 -6.5785800e+05 7.47e-03 6.63e+02  -1.0 1.55e+03    -  9.15e-03 3.77e-02h  1
   6 -1.6952970e+06 1.81e-03 1.61e+02  -1.0 1.49e+03    -  1.48e-02 7.57e-01h  1
   7 -1.7845477e+06 3.82e-04 3.39e+01  -1.0 3.62e+02    -  8.00e-01 7.89e-01h  1 
   8 -1.7729791e+06 2.82e-09 2.64e-12  -1.0 7.62e+01    -  1.00e+00 1.00e+00h  1
   9 -1.8255661e+06 2.27e-13 1.75e-13  -2.5 5.38e-02    -  1.00e+00 1.00e+00f  1
iter    objective    inf_pr   inf_du lg(mu)  ||d||  lg(rg) alpha_du alpha_pr  ls
  10 -1.8270490e+06 4.55e-13 2.47e-13  -5.7 1.72e-03    -  1.00e+00 1.00e+00f  1
  11 -1.8270499e+06 2.27e-13 2.56e-11  -7.0 1.18e-06    -  1.00e+00 1.00e+00h  1


```